### PR TITLE
Fixing issues #1 and #2

### DIFF
--- a/.github/workflows/octomap.yml
+++ b/.github/workflows/octomap.yml
@@ -2,13 +2,13 @@ name: draw-octomap
 on:
   push:
     branches:
-      - master
+      - games
 jobs:
   drawing_map:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@games
       - name: repo-visualizer
         # You may pin to the exact commit or the version.
         # uses: githubocto/repo-visualizer@<SHA>
@@ -25,7 +25,7 @@ jobs:
           # The maximum number of nested folders to show files within. Default: 9
           max_depth: 9
           # The commit message to use when updating the diagram. Default: Repo visualizer: updated diagram
-          commit_message: "Updated octomap [repo-visualizer]"
+          commit_message: "NEW GAME! Updated octomap [repo-visualizer]"
           # The branch name to push the diagram to (branch will be created if it does not yet exist). For example: diagram
           branch: master
           # Whether to push the new commit back to the repository. Must be true or false. Default: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Custom_badge](https://img.shields.io/static/v1?&label=10&message=✓&color=informational&logo=windows&logoColor=9cf&style=flat)
 ![Custom_badge](https://img.shields.io/static/v1?&label=11&message=✓&color=lightgrey&logo=apple&style=flat)
 ![Custom_badge](https://img.shields.io/static/v1?&label=10&message=✓&color=purple&logo=ubuntu&style=flat)
-![GitHub last commit](https://img.shields.io/github/last-commit/bellomia/minecraftverse?label=last%20game&logo=mojangstudios&style=flat)
+![GitHub last commit](https://img.shields.io/github/last-commit/bellomia/minecraftverse/games?label=last%20game&logo=mojangstudios&style=flat)
 ![GitHub repo size](https://img.shields.io/github/repo-size/bellomia/minecraftverse?color=yellow&label=bare%20size&logo=git&style=flat)
 
 Versioning of some amazing (but also some crappy) minecraft worlds


### PR DESCRIPTION
Now we checkout on the local clones inside `.minecraft` the /games branch, which is intended for **gaming-only purposes**. 

So we should fix:

- #1 ) by having the yaml script track commits only in the /games branch... no other "technical" update, made directly on the master branch, could trigger an octomap!

- #2 ) by having the "last game" badge track again only commits pushed to the /games branch, so to strongly enforce its semantic meaning.

Every now and then a manual pull request will merge gaming commits into /master. 
Merging or cherry-picking stuff from /master to /games is discouraged: the gaming branch should remain reserved for gaming-only activity, with the exception of critical fixes or updates.